### PR TITLE
fix(build): Fix build on Mac Os

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+#![deny(missing_docs)]
+
+//! mac_notification_sys requires to link extra libraries, add them here
+fn main() {
+    // Check if the target is macOS
+    if cfg!(target_os = "macos") {
+        // Link the AppKit framework (contains NSImage)
+        println!("cargo:rustc-link-lib=framework=AppKit");
+        // Link the CoreServices framework (contains LaunchServices functions)
+        println!("cargo:rustc-link-lib=framework=CoreServices");
+    }
+}
+


### PR DESCRIPTION
On MacOs build fails with:
Undefined symbols for architecture arm64:
            "_LSCopyApplicationURLsForBundleIdentifier", referenced from:
                _setApplication in libmac_notification_sys-a73ca30ec927359c.rlib[5](54532c69c7c8f551-notify.o)
            "_OBJC_CLASS_$_NSImage", referenced from:
                 in libmac_notification_sys-a73ca30ec927359c.rlib[5](54532c69c7c8f551-notify.o)
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)

notify-rust crate uses mac-notification-sys crate
but it does require to link against Apple's
AppKit framework and CoreServices.

Fix this by creating build.rs that adds the libraries when building on MacOs.